### PR TITLE
Complete component (mobile, desktop)

### DIFF
--- a/components/icons/PlusLight.tsx
+++ b/components/icons/PlusLight.tsx
@@ -1,0 +1,45 @@
+const PlusLight = ({ ...props }) => {
+  return (
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 22 22"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M1 11L20.9985 11"
+        stroke="black"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M1 11L20.9985 11"
+        stroke="black"
+        stroke-opacity="0.2"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M11 21L11 1.00146"
+        stroke="black"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M11 21L11 1.00146"
+        stroke="black"
+        stroke-opacity="0.2"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  )
+}
+
+export default PlusLight

--- a/components/modules/ContentAccordion/ContentAccordion.module.scss
+++ b/components/modules/ContentAccordion/ContentAccordion.module.scss
@@ -1,7 +1,61 @@
 .root {
   // add your styles here
-  padding: 10rem 0rem;
-  background: orange;
-  opacity: .5;
-  border-bottom: 1px solid black;
+  @apply container default-grid pb-25;
+  @apply md:pb-85;
+
+  .headline{
+    @apply text-blue col-start-1 col-span-2 text-center mb-55;
+    @apply md:col-start-1 md:col-span-12 md:mb-55;
+  }
+
+  .accordionsContainer{
+    @apply col-start-1 col-span-2;
+    @apply md:col-start-2 md:col-span-10;  
+  }
+
+  .accordionContainer{
+    @apply py-20 border-t-[1.5px] border-greyscale-4;
+    @apply md:py-40;
+  }
+
+  .accordionContainer:last-child{
+    @apply border-b-[1.5px];
+  }
+
+  .accordionHeadline{
+    @apply text-blue text-20 font-bold cursor-pointer flex flex-row justify-between;
+    line-height: 2.8rem;
+
+    .plusIcon{
+      @apply visible opacity-100 absolute top-0 right-0 transition-all duration-500;
+    }
+    
+    .minusIcon{
+      @apply invisible opacity-0 absolute top-0 right-0 transition-all duration-500;
+    }
+
+    > div{
+      @apply relative text-black; 
+    }
+
+    path{
+      @apply stroke-black stroke-[1.5px];
+    }
+
+    &.open{
+      .plusIcon{
+        @apply invisible opacity-0;
+      }
+
+      .minusIcon{
+        @apply visible opacity-100;
+      }
+    }
+  }
+
+  .accordionCopy{
+    @apply pt-20 text-20 font-normal;
+    @apply md:pt-30;
+    line-height: 3rem;
+  }
 }

--- a/components/modules/ContentAccordion/ContentAccordion.module.scss
+++ b/components/modules/ContentAccordion/ContentAccordion.module.scss
@@ -23,7 +23,8 @@
   }
 
   .accordionHeadline{
-    @apply text-blue text-20 font-bold cursor-pointer flex flex-row justify-between;
+    @apply text-blue font-bold cursor-pointer flex flex-row justify-between;
+    font-size: 2.0rem;
     line-height: 2.8rem;
 
     .plusIcon{
@@ -54,8 +55,7 @@
   }
 
   .accordionCopy{
-    @apply pt-20 text-20 font-normal;
+    @apply typo-large-paragraph pt-20;
     @apply md:pt-30;
-    line-height: 3rem;
   }
 }

--- a/components/modules/ContentAccordion/ContentAccordion.tsx
+++ b/components/modules/ContentAccordion/ContentAccordion.tsx
@@ -1,14 +1,60 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useState } from 'react'
+import c from 'classnames'
+import parse from 'html-react-parser'
 import styles from './ContentAccordion.module.scss'
 import IContentAccordion from './ContentAccordion.interface'
+import { Minus } from '@components/icons'
+import PlusLight from '@components/icons/PlusLight'
 
-const ContentAccordionModule:FunctionComponent<{ module: IContentAccordion }> = ({ module }) => {
-  console.log(module)
+const ContentAccordionModule: FunctionComponent<{
+  module: IContentAccordion
+}> = ({ module }) => {
+  const { headline, accordion } = module
+  const [accordionStatus, setAccordionStatus] = useState(
+    accordion.map(() => false)
+  )
+
+  const toggleAccordion = (i: number) => {
+    accordionStatus[i] = !accordionStatus[i]
+    setAccordionStatus(accordionStatus.slice())
+  }
   return (
-    <div
-      className={`${styles.root} container`}
-    >
-      Contentaccordion Module
+    <div className={`${styles.root}`}>
+      <h4 className={c(styles.headline)}>{headline}</h4>
+      <div className={c(styles.accordionsContainer)}>
+        {accordion &&
+          accordion.map((a, index) => {
+            return (
+              <div key={a.headline} className={c(styles.accordionContainer)}>
+                <div
+                  className={c(styles.accordionHeadline, {
+                    [styles.open]: accordionStatus[index],
+                  })}
+                  onClick={() => {
+                    toggleAccordion(index)
+                  }}
+                >
+                  {a.headline}
+                  <div>
+                    <PlusLight className={c(styles.plusIcon)} color={'black'} />
+                    <Minus
+                      width={22}
+                      color={'black'}
+                      className={c(styles.minusIcon)}
+                    />
+                  </div>
+                </div>
+                <div
+                  className={c('accordion', {
+                    visible: accordionStatus[index],
+                  })}
+                >
+                  <div className={c(styles.accordionCopy)}>{parse(a.copy)}</div>
+                </div>
+              </div>
+            )
+          })}
+      </div>
     </div>
   )
 }

--- a/components/modules/ContentAccordion/ContentAccordion.tsx
+++ b/components/modules/ContentAccordion/ContentAccordion.tsx
@@ -20,7 +20,9 @@ const ContentAccordionModule: FunctionComponent<{
   }
   return (
     <div className={`${styles.root}`}>
-      <h4 className={c(styles.headline)}>{headline}</h4>
+      <h4 className={c(styles.headline)}>
+        {headline && <span>{headline}</span>}
+      </h4>
       <div className={c(styles.accordionsContainer)}>
         {accordion &&
           accordion.map((a, index) => {

--- a/styles/typography.scss
+++ b/styles/typography.scss
@@ -68,6 +68,11 @@
     font-size: 2.5rem;
     line-height: 3rem;
     letter-spacing: -0.02em;
+
+    @screen md {
+      font-size: 3.5rem;
+      line-height: 4rem;
+    }
   }
 
   .typo-h5,


### PR DESCRIPTION
Desktop and mobile view. One thing I am not convinced, though, the accordion data only includes headline and copy fields, but according to Figma the copy element includes several titles and paragraphs (see image below), I am currently parsing that with react-parser but I am not styling potential titles, you think we could improve the data coming from the CMS to match that from the design?

![image](https://user-images.githubusercontent.com/6061114/173993662-40eb5543-f842-4c50-93ea-8b400632acfb.png)
