### PR TITLE
fix build errors

### DIFF
--- a/pages/cart.module.scss
+++ b/pages/cart.module.scss
@@ -11,21 +11,24 @@
   }
 
   .learnMoreText {
-    @apply text-center underline font-bold typo-small-paragraph mb-40;
+    @apply text-center underline font-bold mb-40;
+    // typo-small-paragraph;
   }
 
   .subtotalContainer {
-    @apply typo-h5 flex flex-row justify-between items-center mb-35;
+    @apply flex flex-row justify-between items-center mb-35;
+    // typo-h5
 
     h5 {
       @apply font-bold;
     }
     span {
-      @apply font-bold md:typo-large-paragraph;
+      @apply font-bold;
+      // md:typo-large-paragraph
     }
   }
 
   .cartProductContainer {
-    @apply pb-40 mb-40 light-border-b;
+    @apply pb-40 mb-40 border-greyscale-4 border-b-[0.15rem];
   }
 }

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -160,16 +160,16 @@ export default function Cart({
               <div
                 className={'border-b-[1rem] border-white rounded-full mb-30'}
               ></div>
-              <div className={styles.learnMoreText}>
+              <div className={c(styles.learnMoreText, 'typo-small-paragraph')}>
                 {Translations.LEARN_MORE}
               </div>
               <div className={'border-b-[0.1rem] border-[#C4C4C4] mb-40'}></div>
             </div>
           )}
 
-          <div className={styles.subtotalContainer}>
-            <h5>{`${Translations.CART.SUBTOTAL}:`}</h5>
-            <span>{subTotal}</span>
+          <div className={c(styles.subtotalContainer, 'typo-h5')}>
+            <h5 className="font-bold">{`${Translations.CART.SUBTOTAL}:`}</h5>
+            <span className="md:typo-large-paragraph">{subTotal}</span>
           </div>
           <div>
             <Button


### PR DESCRIPTION
@alexscro  apparently builds were only failing because of the typo classes in the utility layer.
For some reason they did not exist yet before the cart.module.scss file was processed, moving the classes from @apply to the className prop fixes the errors!